### PR TITLE
update urls for personal goals, battle goals and road/city events

### DIFF
--- a/src/Gallery.tsx
+++ b/src/Gallery.tsx
@@ -57,7 +57,7 @@ class Gallery extends React.Component<NoProps, NoState> {
       height: 300
     };
     const cards = allBattleGoals.map(it => {
-      const imgUrl = `https://raw.githubusercontent.com/any2cards/gloomhaven/master/images/battle-goals/${urlToScanFor(it)}.png`;
+      const imgUrl = `https://raw.githubusercontent.com/any2cards/gloomhaven/master/images/battle-goals/gloomhaven/${urlToScanFor(it)}.png`;
       const style = {
         display: 'flex',
         flexDirection: 'row'

--- a/src/cards/PersonalGoalCard.tsx
+++ b/src/cards/PersonalGoalCard.tsx
@@ -13,6 +13,6 @@ export class PersonalGoalCard extends React.Component<PersonalGoalCardProps, NoS
       borderRadius: '20px'
     } as React.CSSProperties;
     const cardId = this.props.cardId;
-    return <img key={cardId} style={style} src={"https://raw.githubusercontent.com/any2cards/gloomhaven/master/images/personal-goals/pg-" + cardId + ".png"} alt='personal goal'/>
+    return <img key={cardId} style={style} src={"https://raw.githubusercontent.com/any2cards/gloomhaven/master/images/personal-quests/gloomhaven/gh-pq-" + cardId + ".png"} alt='personal goal'/>
   }
 }

--- a/src/events/EventCard.tsx
+++ b/src/events/EventCard.tsx
@@ -24,7 +24,7 @@ export default class EventCard extends React.Component<EventCardProps, NoState> 
   eventCardImageUrl() {
     const twoDigitNumber = (this.props.eventCardId <= 9 ? "0" : "") + this.props.eventCardId;
     const imageName = this.props.name.toLowerCase();
-    const imageBaseUrl = "https://raw.githubusercontent.com/any2cards/gloomhaven/master/images/events/" + imageName + "/" + imageName.charAt(0) + "e-" + twoDigitNumber + "-";
+    const imageBaseUrl = "https://raw.githubusercontent.com/any2cards/gloomhaven/master/images/events/gloomhaven/" + imageName + "/gh-" + imageName.charAt(0) + "e-" + twoDigitNumber + "-";
     const sideUrlPart = this.props.side === Side.Back ? 'b' : 'f';
     return imageBaseUrl + sideUrlPart + '.png';
   }


### PR DESCRIPTION
Tested locally.

Not (yet) fixed: Draw random item design. URL is bad but we could substitute with https://github.com/any2cards/gloomhaven/tree/master/images/items/gloomhaven (needs some implementation, though)